### PR TITLE
User/shlabisa/mlops 79 ga add flight arrival and departure blocks

### DIFF
--- a/backend/ga/utils.py
+++ b/backend/ga/utils.py
@@ -20,8 +20,8 @@ TO_RAD = math.pi/180.0
 
 # PLANE TIME CONSTANTS
 PLANE_WEEK_DAY: int = 2  # Wednesday = 2 according to date.weekday()
-PLANE_ARRIVAL_TIME_BLOCK: tuple[time, time] = (time(8, 0, 0), time(10, 0, 0))
-PLANE_DEPARTURE_TIME_BLOCK: tuple[time, time] = (time(14, 0, 0), time(16, 30, 0))
+PLANE_ARRIVAL_TIME_BLOCK: tuple[time, time] = (time(8, 0, 0), time(9, 0, 0))
+PLANE_DEPARTURE_TIME_BLOCK: tuple[time, time] = (time(15, 0, 0), time(17, 0, 0))
 
 def degrees_string_to_float(degrees: str) -> float:
     """

--- a/backend/ga/utils.py
+++ b/backend/ga/utils.py
@@ -18,6 +18,11 @@ ZENITH = 90 + 50 / 60  # Official zenith for sunrise/sunset in degrees
 # MATH CONSTANT
 TO_RAD = math.pi/180.0
 
+# PLANE TIME CONSTANTS
+PLANE_WEEK_DAY: int = 2  # Wednesday = 2 according to date.weekday()
+PLANE_ARRIVAL_TIME_BLOCK: tuple[time, time] = (time(8, 0, 0), time(10, 0, 0))
+PLANE_DEPARTURE_TIME_BLOCK: tuple[time, time] = (time(14, 0, 0), time(16, 30, 0))
+
 def degrees_string_to_float(degrees: str) -> float:
     """
     Convert a string in the format "hh:mm:ss.s" to a float in degrees.
@@ -295,3 +300,42 @@ def force_range(value: float, max_value: float):
     elif value >= max_value:
         return value - max_value
     return value
+
+def get_plane_arrival_and_departure_blocks(
+    date: date,
+    plane_weekday: int = PLANE_WEEK_DAY,
+    plane_arrival_time_block: tuple[time, time] = PLANE_ARRIVAL_TIME_BLOCK,
+    plane_departure_time_block: tuple[time, time] = PLANE_DEPARTURE_TIME_BLOCK
+) -> list[tuple[datetime, datetime]]:
+    """
+    Retrieve the plane arrival and departure time blocks for a specified date.
+
+    Args:
+        date (date): The date for which to retrieve the plane arrival and departure blocks.
+        plane_weekday (int): The weekday (0=Monday, 6=Sunday) when the plane operates. 
+                             Defaults to PLANE_WEEK_DAY.
+        plane_arrival_time_block (tuple[time, time]): A tuple representing the start and end time 
+                                                      for plane arrivals. Defaults to PLANE_ARRIVAL_TIME_BLOCK.
+        plane_departure_time_block (tuple[time, time]): A tuple representing the start and end time 
+                                                       for plane departures. Defaults to PLANE_DEPARTURE_TIME_BLOCK.
+
+    Returns:
+        list[tuple[datetime, datetime]]: A list of tuples, each containing:
+            - Arrival or departure start time as a datetime object.
+            - Arrival or departure end time as a datetime object.
+    """
+    # Initialize an empty list to hold the arrival and departure blocks
+    plane_arrival_and_departure_blocks: list[tuple[datetime, datetime]] = []
+
+    # Check if the specified date is the correct weekday for operations
+    if date.weekday() == plane_weekday:
+        # Define the time blocks for arrival and departure
+        time_blocks = [plane_arrival_time_block, plane_departure_time_block]
+
+        # Combine the date with each time block and append to the list
+        for (start_time, end_time) in time_blocks:
+            start_datetime = datetime.combine(date, start_time)
+            end_datetime = datetime.combine(date, end_time)
+            plane_arrival_and_departure_blocks.append((start_datetime, end_datetime))
+
+    return plane_arrival_and_departure_blocks

--- a/backend/tests/ga/test_proposal.py
+++ b/backend/tests/ga/test_proposal.py
@@ -10,11 +10,11 @@ from ga.proposal import Proposal
         (datetime(2025, 8, 27, 7, 55, 0), False),   # Clash with arrival time block
         (datetime(2025, 8, 27, 8, 0, 0), False),   # Clash with arrival time block
         (datetime(2025, 8, 27, 9, 0, 0), False),    # Clash with arrival time block
-        (datetime(2025, 8, 27, 10, 0, 0), False),   # Clash with arrival time block
+        (datetime(2025, 8, 27, 10, 0, 0), True),   # No clash with both arrival and departure
         (datetime(2025, 8, 27, 10, 1, 0), True),    # No clash with both arrival and departure
-        (datetime(2025, 8, 27, 13, 0, 0), False),    # Clash with depature time block
-        (datetime(2025, 8, 27, 14, 11, 0), False),  # Clash with depature time block
-        (datetime(2025, 8, 27, 17, 0, 0), True),    # No clash with both arrival and departure
+        (datetime(2025, 8, 27, 13, 0, 0), True),    # No clash with both arrival and departure
+        (datetime(2025, 8, 27, 17, 0, 0), False),  # Clash with depature time block
+        (datetime(2025, 8, 27, 22, 11, 0), True),    # No clash with both arrival and departure
 
         # Friday
         (datetime(2025, 8, 29, 7, 55, 0), True),    # No clash with both arrival and departure

--- a/backend/tests/ga/test_proposal.py
+++ b/backend/tests/ga/test_proposal.py
@@ -1,0 +1,49 @@
+import pytest
+from datetime import datetime, date, time, timedelta
+from ga.proposal import Proposal
+
+@pytest.mark.parametrize(
+    "proposed_start_datetime, expected_result",
+    [
+        # Wednesday
+        (datetime(2025, 8, 27, 6, 30, 0), True),    # No clash with both arrival and departure
+        (datetime(2025, 8, 27, 7, 55, 0), False),   # Clash with arrival time block
+        (datetime(2025, 8, 27, 8, 0, 0), False),   # Clash with arrival time block
+        (datetime(2025, 8, 27, 9, 0, 0), False),    # Clash with arrival time block
+        (datetime(2025, 8, 27, 10, 0, 0), False),   # Clash with arrival time block
+        (datetime(2025, 8, 27, 10, 1, 0), True),    # No clash with both arrival and departure
+        (datetime(2025, 8, 27, 13, 0, 0), False),    # Clash with depature time block
+        (datetime(2025, 8, 27, 14, 11, 0), False),  # Clash with depature time block
+        (datetime(2025, 8, 27, 17, 0, 0), True),    # No clash with both arrival and departure
+
+        # Friday
+        (datetime(2025, 8, 29, 7, 55, 0), True),    # No clash with both arrival and departure
+        (datetime(2025, 8, 29, 14, 11, 0), True),  # No clash with both arrival and departure
+        (datetime(2025, 8, 29, 22, 0, 0), True),    # No clash with both arrival and departure
+
+    ]
+)
+def test_plane_arrival_and_departure_constraint_met(proposed_start_datetime: datetime, expected_result: bool):
+    """
+    Test the plane arrival and departure constraint checks for various proposed start datetimes.
+    """
+    proposal = Proposal(
+        id=1,
+        description="Test Proposal",
+        proposal_id="P123",
+        owner_email="owner@example.com",
+        instrument_product="Instrument A",
+        instrument_integration_time=10.0,
+        instrument_band="Band 1",
+        instrument_pool_resources="Resource A",
+        lst_start_time=time(0, 0),
+        lst_start_end_time=time(23, 59),
+        simulated_duration=3600,  # 1 hour
+        night_obs=False,
+        avoid_sunrise_sunset=False,
+        minimum_antennas=1,
+        general_comments="",
+    )
+
+    result = proposal.plane_arrival_and_departure_constraint_met(proposed_start_datetime)
+    assert result == expected_result, f"Expected {expected_result} but got {result} for proposed start time {proposed_start_datetime}"

--- a/backend/tests/ga/test_utils.py
+++ b/backend/tests/ga/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import date, time, datetime, timezone, timedelta
-from ga.utils import lst_to_utc, get_sunrise_sunset
+from ga.utils import lst_to_utc, get_sunrise_sunset, get_plane_arrival_and_departure_blocks
 
 SARAO_CPT_LAT: float = -33.94470
 SARAO_CPT_LON: float = 18.47810
@@ -184,3 +184,30 @@ def test_get_sunrise_sunset_does_not_match_wrong_values(test_date: date, wrong_e
 
     assert sunrise_delta > 60, f"Sunrise calculation too close to wrong value ({sunrise_delta:.2f} seconds)"
     assert sunset_delta > 60, f"Sunset calculation too close to wrong value ({sunset_delta:.2f} seconds)"
+
+@pytest.mark.parametrize(
+    "test_date, expected_blocks",
+    [
+        (date(2025, 4, 30), [       # Wednesday (a long time ago)
+            (datetime(2025, 4, 30, 8, 0, 0), datetime(2025, 4, 30, 10, 0, 0)),  # Arrival
+            (datetime(2025, 4, 30, 14, 0, 0), datetime(2025, 4, 30, 16, 30, 0)),  # Departure
+        ]),
+        (date(2025, 8, 24), []),    # Sunday
+        (date(2025, 8, 25), []),    # Monday
+        (date(2025, 8, 26), []),    # Tuesday
+        (date(2025, 8, 27), [       # Wednesday
+            (datetime(2025, 8, 27, 8, 0, 0), datetime(2025, 8, 27, 10, 0, 0)),  # Arrival
+            (datetime(2025, 8, 27, 14, 0, 0), datetime(2025, 8, 27, 16, 30, 0)),  # Departure
+        ]),
+        (date(2025, 8, 28), []),    # Thursday
+        (date(2025, 8, 29), []),    # Friday
+        (date(2025, 8, 30), [])     # Saturday 
+    ]
+)
+def test_get_plane_arrival_and_departure_blocks(test_date: date, expected_blocks: list[tuple[datetime, datetime]]):
+    """
+    Test the plane arrival and departure blocks for various dates.
+    """
+
+    plane_blocks: list[tuple[datetime, datetime]] = get_plane_arrival_and_departure_blocks(test_date)
+    assert plane_blocks == expected_blocks, f"Expected {expected_blocks}, but got {plane_blocks}"

--- a/backend/tests/ga/test_utils.py
+++ b/backend/tests/ga/test_utils.py
@@ -189,15 +189,15 @@ def test_get_sunrise_sunset_does_not_match_wrong_values(test_date: date, wrong_e
     "test_date, expected_blocks",
     [
         (date(2025, 4, 30), [       # Wednesday (a long time ago)
-            (datetime(2025, 4, 30, 8, 0, 0), datetime(2025, 4, 30, 10, 0, 0)),  # Arrival
-            (datetime(2025, 4, 30, 14, 0, 0), datetime(2025, 4, 30, 16, 30, 0)),  # Departure
+            (datetime(2025, 4, 30, 8, 0, 0), datetime(2025, 4, 30, 9, 0, 0)),  # Arrival
+            (datetime(2025, 4, 30, 15, 0, 0), datetime(2025, 4, 30, 17, 0, 0)),  # Departure
         ]),
         (date(2025, 8, 24), []),    # Sunday
         (date(2025, 8, 25), []),    # Monday
         (date(2025, 8, 26), []),    # Tuesday
         (date(2025, 8, 27), [       # Wednesday
-            (datetime(2025, 8, 27, 8, 0, 0), datetime(2025, 8, 27, 10, 0, 0)),  # Arrival
-            (datetime(2025, 8, 27, 14, 0, 0), datetime(2025, 8, 27, 16, 30, 0)),  # Departure
+            (datetime(2025, 8, 27, 8, 0, 0), datetime(2025, 8, 27, 9, 0, 0)),  # Arrival
+            (datetime(2025, 8, 27, 15, 0, 0), datetime(2025, 8, 27, 17, 0, 0)),  # Departure
         ]),
         (date(2025, 8, 28), []),    # Thursday
         (date(2025, 8, 29), []),    # Friday


### PR DESCRIPTION
Addresses [MLOPS-79](https://skaafrica.atlassian.net/browse/MLOPS-79)

The goal is to add a constraint that will prevent scheduling observations within the plane arrival and departure time block.

According to `Sarah`, the plane blocks should be dynamic, and are usually on Wednesday (08:00-09:00) and (15:00-17:00). See the calendar reference image below:
<img width="1666" height="1080" alt="Screenshot from 2025-08-29 13-36-29" src="https://github.com/user-attachments/assets/4f071d1b-7067-4ddf-a939-debb9108d93f" />

I've implemented a fun to get these values, and used it within the GA module, then implemented pytests.

Just run:
```bash
venv/bin/python -m pytest tests/ga/test_utils.py tests/ga/test_proposal.py
```

And you should get something like this:
<img width="1451" height="193" alt="Screenshot from 2025-08-29 17-02-21" src="https://github.com/user-attachments/assets/8b620c37-74c2-46cd-9ada-e6ac53dcccf9" />

Thanks, and I look forward to your feedback.